### PR TITLE
补填更新日志

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 def secrets = System.getenv("GOOGLE_SERVICES_JSON")
 def analyticsEnabled = secrets != null
 
+
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 


### PR DESCRIPTION
更新日志20250707:
1.当联网权限未授予或者未申明时，设置 store 为不可选中并给出提示。
2.在主界面双击返回键可彻底退出软件，不再残留后台。